### PR TITLE
chore(docs): use different sample config files for tests and docs

### DIFF
--- a/example-config.json
+++ b/example-config.json
@@ -1,4 +1,32 @@
 {
   "spaceId": "source space id",
-  "managementToken": "destination space management token"
+  "environmentId": "master",
+  "managementToken": "destination space management token",
+  "deliveryToken": "token to export both entries and assets from the Contentful Delivery API",
+  "exportDir": "/path/to/export/directory",
+  "saveFile": true,
+  "contentFile": "export.json",
+  "includeDrafts": false,
+  "includeArchived": false,
+  "skipContentModel": false,
+  "skipEditorInterfaces": false,
+  "skipContent": false,
+  "skipRoles": false,
+  "skipWebhooks": false,
+  "contentOnly": false,
+  "queryEntries": [
+    "content_type=<content_type_id>",
+    "sys.id=<entry_id>"
+  ],
+  "queryAssets": [
+    "fields.title=Example"
+  ],
+  "downloadAssets": false,
+  "host": "api.contentful.com",
+  "proxy": "https://user:password@host:port",
+  "rawProxy": false,
+  "maxAllowedLimit": 1000,
+  "limit": 25000,
+  "errorLogFile": "/path/to/error.log",
+  "useVerboseRenderer": false
 }

--- a/example-config.test.json
+++ b/example-config.test.json
@@ -1,0 +1,4 @@
+{
+  "spaceId": "source space id",
+  "managementToken": "destination space management token"
+}

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -163,11 +163,11 @@ test('Runs Contentful Export and downloads assets', () => {
 
 test('Creates a valid and correct opts object', () => {
   const errorLogFile = 'errorlogfile'
-  const exampleConfig = require('../../example-config.json')
+  const exampleConfig = require('../../example-config.test.json')
 
   return runContentfulExport({
     errorLogFile,
-    config: resolve(__dirname, '..', '..', 'example-config.json')
+    config: resolve(__dirname, '..', '..', 'example-config.test.json')
   })
     .then(() => {
       expect(initClient.mock.calls[0][0].skipContentModel).toBeFalsy()

--- a/test/unit/parseOptions.test.js
+++ b/test/unit/parseOptions.test.js
@@ -57,7 +57,7 @@ test('parseOptions sets correct default options', () => {
 })
 
 test('parseOption accepts config file', () => {
-  const configFileName = 'example-config.json'
+  const configFileName = 'example-config.test.json'
   const config = require(resolve(basePath, configFileName))
 
   const options = parseOptions({


### PR DESCRIPTION
To unblock #469

The expanded example-config seems a great contribution to me, however as it is also referred to by some unit tests, we have to add a second config and use that one for testing from now on. The expanded config is not suited for that, as it has many explanatory property values that would break the tests.